### PR TITLE
fixes indexing key DK-1832

### DIFF
--- a/controllers/mongodbuser_controller.go
+++ b/controllers/mongodbuser_controller.go
@@ -116,7 +116,7 @@ func (r *MongoDBUserReconciler) requestsForDatabaseChange(o client.Object) []rec
 	ctx := context.Background()
 	var list infrav1beta1.MongoDBUserList
 	if err := r.List(ctx, &list, client.MatchingFields{
-		secretIndexKey: objectKey(s).String(),
+		dbIndexKey: objectKey(s).String(),
 	}); err != nil {
 		return nil
 	}

--- a/controllers/postgresqluser_controller.go
+++ b/controllers/postgresqluser_controller.go
@@ -116,7 +116,7 @@ func (r *PostgreSQLUserReconciler) requestsForDatabaseChange(o client.Object) []
 	ctx := context.Background()
 	var list infrav1beta1.PostgreSQLUserList
 	if err := r.List(ctx, &list, client.MatchingFields{
-		secretIndexKey: objectKey(s).String(),
+		dbIndexKey: objectKey(s).String(),
 	}); err != nil {
 		return nil
 	}


### PR DESCRIPTION
## Current situation
User reconciling does not get triggered if the referenced database resource has been changed.

## Proposal
The wrong index key was used in the mapping function.
