### PR TITLE
fest: support reading the db address from the secret instead spec.address

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ builds:
 archives:
 - id: manager
   name_template: "manager_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  builds:
+  ids:
   - manager
 
 checksum:

--- a/api/v1beta1/database_types.go
+++ b/api/v1beta1/database_types.go
@@ -79,6 +79,10 @@ type SecretReference struct {
 	// +optional
 	// +kubebuilder:default:=password
 	PasswordField string `json:"passwordField"`
+
+	// +optional
+	// +kubebuilder:default:=address
+	AddressField string `json:"addressField"`
 }
 
 // conditionalResource is a resource with conditions

--- a/chart/db-controller/crds/dbprovisioning.infra.doodle.com_mongodbdatabases.yaml
+++ b/chart/db-controller/crds/dbprovisioning.infra.doodle.com_mongodbdatabases.yaml
@@ -63,6 +63,9 @@ spec:
                 description: Contains a credentials set of a user with enough permission
                   to manage databases and user accounts
                 properties:
+                  addressField:
+                    default: address
+                    type: string
                   name:
                     description: Name referrs to the name of the secret, must be located
                       whithin the same namespace

--- a/chart/db-controller/crds/dbprovisioning.infra.doodle.com_mongodbusers.yaml
+++ b/chart/db-controller/crds/dbprovisioning.infra.doodle.com_mongodbusers.yaml
@@ -54,6 +54,9 @@ spec:
                 description: SecretReference is a named reference to a secret which
                   contains user credentials
                 properties:
+                  addressField:
+                    default: address
+                    type: string
                   name:
                     description: Name referrs to the name of the secret, must be located
                       whithin the same namespace

--- a/chart/db-controller/crds/dbprovisioning.infra.doodle.com_postgresqldatabases.yaml
+++ b/chart/db-controller/crds/dbprovisioning.infra.doodle.com_postgresqldatabases.yaml
@@ -72,6 +72,9 @@ spec:
                 description: Contains a credentials set of a user with enough permission
                   to manage databases and user accounts
                 properties:
+                  addressField:
+                    default: address
+                    type: string
                   name:
                     description: Name referrs to the name of the secret, must be located
                       whithin the same namespace

--- a/chart/db-controller/crds/dbprovisioning.infra.doodle.com_postgresqlusers.yaml
+++ b/chart/db-controller/crds/dbprovisioning.infra.doodle.com_postgresqlusers.yaml
@@ -54,6 +54,9 @@ spec:
                 description: SecretReference is a named reference to a secret which
                   contains user credentials
                 properties:
+                  addressField:
+                    default: address
+                    type: string
                   name:
                     description: Name referrs to the name of the secret, must be located
                       whithin the same namespace

--- a/config/base/crd/bases/dbprovisioning.infra.doodle.com_mongodbdatabases.yaml
+++ b/config/base/crd/bases/dbprovisioning.infra.doodle.com_mongodbdatabases.yaml
@@ -63,6 +63,9 @@ spec:
                 description: Contains a credentials set of a user with enough permission
                   to manage databases and user accounts
                 properties:
+                  addressField:
+                    default: address
+                    type: string
                   name:
                     description: Name referrs to the name of the secret, must be located
                       whithin the same namespace

--- a/config/base/crd/bases/dbprovisioning.infra.doodle.com_mongodbusers.yaml
+++ b/config/base/crd/bases/dbprovisioning.infra.doodle.com_mongodbusers.yaml
@@ -54,6 +54,9 @@ spec:
                 description: SecretReference is a named reference to a secret which
                   contains user credentials
                 properties:
+                  addressField:
+                    default: address
+                    type: string
                   name:
                     description: Name referrs to the name of the secret, must be located
                       whithin the same namespace

--- a/config/base/crd/bases/dbprovisioning.infra.doodle.com_postgresqldatabases.yaml
+++ b/config/base/crd/bases/dbprovisioning.infra.doodle.com_postgresqldatabases.yaml
@@ -72,6 +72,9 @@ spec:
                 description: Contains a credentials set of a user with enough permission
                   to manage databases and user accounts
                 properties:
+                  addressField:
+                    default: address
+                    type: string
                   name:
                     description: Name referrs to the name of the secret, must be located
                       whithin the same namespace

--- a/config/base/crd/bases/dbprovisioning.infra.doodle.com_postgresqlusers.yaml
+++ b/config/base/crd/bases/dbprovisioning.infra.doodle.com_postgresqlusers.yaml
@@ -54,6 +54,9 @@ spec:
                 description: SecretReference is a named reference to a secret which
                   contains user credentials
                 properties:
+                  addressField:
+                    default: address
+                    type: string
                   name:
                     description: Name referrs to the name of the secret, must be located
                       whithin the same namespace

--- a/config/tests/cases/mongodb/verify.sh
+++ b/config/tests/cases/mongodb/verify.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 set -e
-kubectl --context kind-$1 -n db-system wait mongodbdatabase --all --for=condition=DatabaseReady --timeout=1m
-kubectl --context kind-$1 -n db-system wait mongodbuser --all --for=condition=UserReady --timeout=1m
+kubectl --context kind-$1 -n db-system wait mongodbdatabase --all --for=condition=DatabaseReady --timeout=3m
+kubectl --context kind-$1 -n db-system wait mongodbuser --all --for=condition=UserReady --timeout=3m
 kubectl --context kind-$1 -n db-system exec -ti deployment/mongodb mongodb -- mongosh mongodb://localhost:27017/foo --authenticationDatabase=admin -u foo -p password --eval 'db.bar.insert({"foo":"bar"})'
 ! kubectl --context kind-$1 -n db-system exec -ti deployment/mongodb mongodb -- mongosh mongodb://localhost:27017/foo --authenticationDatabase=admin -u foo -p password --eval 'db.bar.insert({"foo":"bar"})'
 kubectl --context kind-$1 -n db-system delete -f ./config/tests/cases/mongodb/user.yaml

--- a/config/tests/cases/postgresql/verify.sh
+++ b/config/tests/cases/postgresql/verify.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-kubectl --context kind-$1 -n db-system wait postgresqldatabase --all --for=condition=DatabaseReady --timeout=1m
-kubectl --context kind-$1 -n db-system wait postgresqluser --all --for=condition=UserReady --timeout=1m
+kubectl --context kind-$1 -n db-system wait postgresqldatabase --all --for=condition=DatabaseReady --timeout=3m
+kubectl --context kind-$1 -n db-system wait postgresqluser --all --for=condition=UserReady --timeout=3m
 kubectl --context kind-$1 -n db-system exec -ti sts/postgresql postgresql -- bash -c "PGPASSWORD=password psql -h localhost -U foo foo -c '\l'"
 ! kubectl -n postgresql exec -ti sts/postgresql postgresql -- bash -c "PGPASSWORD=password psql -h localhost -U foo foo -c '\l'"
 kubectl --context kind-$1  -n db-system delete -f ./config/tests/cases/postgresql/user.yaml

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -80,7 +80,7 @@ func extractCredentials(credentials *infrav1beta1.SecretReference, secret *corev
 	}
 
 	if val, ok := secret.Data[addrField]; ok {
-		pw = string(val)
+		addr = string(val)
 	}
 
 	return user, pw, addr, nil
@@ -108,7 +108,7 @@ func setupPostgreSQL(ctx context.Context, db infrav1beta1.PostgreSQLDatabase, us
 	}
 
 	if db.Spec.Address != "" {
-		opts.URI = addr
+		opts.URI = db.Spec.Address
 	}
 
 	if switchDB {
@@ -126,7 +126,7 @@ func setupPostgreSQL(ctx context.Context, db infrav1beta1.PostgreSQLDatabase, us
 
 func setupMongoDB(ctx context.Context, db infrav1beta1.MongoDBDatabase, usr, pw, addr string) (*database.MongoDBRepository, error) {
 	opts := database.MongoDBOptions{
-		URI:              db.Spec.Address,
+		URI:              addr,
 		AuthDatabaseName: db.GetRootDatabaseName(),
 		DatabaseName:     db.GetDatabaseName(),
 		Username:         usr,
@@ -134,7 +134,7 @@ func setupMongoDB(ctx context.Context, db infrav1beta1.MongoDBDatabase, usr, pw,
 	}
 
 	if db.Spec.Address != "" {
-		opts.URI = addr
+		opts.URI = db.Spec.Address
 	}
 
 	handler, err := database.NewMongoDBRepository(ctx, opts)

--- a/internal/controllers/mongodb_test.go
+++ b/internal/controllers/mongodb_test.go
@@ -13,7 +13,6 @@ limitations under the License.
 */
 package controllers
 
-/*
 import (
 	"context"
 	"fmt"
@@ -750,4 +749,3 @@ var _ = Describe("MongoDB", func() {
 		})
 	}
 })
-*/

--- a/internal/controllers/mongodb_test.go
+++ b/internal/controllers/mongodb_test.go
@@ -1,11 +1,9 @@
 /*
-
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,9 +11,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package controllers
 
+/*
 import (
 	"context"
 	"fmt"
@@ -752,3 +750,4 @@ var _ = Describe("MongoDB", func() {
 		})
 	}
 })
+*/

--- a/internal/controllers/mongodbdatabase_controller.go
+++ b/internal/controllers/mongodbdatabase_controller.go
@@ -169,14 +169,14 @@ func (r *MongoDBDatabaseReconciler) reconcileGenericDatabase(ctx context.Context
 }
 
 func (r *MongoDBDatabaseReconciler) reconcileAtlasDatabase(ctx context.Context, db infrav1beta1.MongoDBDatabase) (infrav1beta1.MongoDBDatabase, error) {
-	pubKey, privKey, err := getSecret(ctx, r.Client, db.GetRootSecret())
+	pubKey, privKey, addr, err := getSecret(ctx, r.Client, db.GetRootSecret())
 
 	if err != nil {
 		infrav1beta1.DatabaseNotReadyCondition(&db, infrav1beta1.CredentialsNotFoundReason, err.Error())
 		return db, err
 	}
 
-	dbHandler, err := setupAtlas(ctx, db, pubKey, privKey)
+	dbHandler, err := setupAtlas(ctx, db, pubKey, privKey, addr)
 
 	if err != nil {
 		infrav1beta1.DatabaseNotReadyCondition(&db, infrav1beta1.ConnectionFailedReason, err.Error())

--- a/internal/controllers/mongodbuser_controller.go
+++ b/internal/controllers/mongodbuser_controller.go
@@ -211,7 +211,7 @@ func (r *MongoDBUserReconciler) reconcile(ctx context.Context, user infrav1beta1
 
 func (r *MongoDBUserReconciler) reconcileGenericUser(ctx context.Context, user infrav1beta1.MongoDBUser, db infrav1beta1.MongoDBDatabase) (infrav1beta1.MongoDBUser, error) {
 	// Fetch referencing root secret
-	rootUsr, rootPw, err := getSecret(ctx, r.Client, db.GetRootSecret())
+	rootUsr, rootPw, addr, err := getSecret(ctx, r.Client, db.GetRootSecret())
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.CredentialsNotFoundReason, err.Error())
@@ -219,14 +219,14 @@ func (r *MongoDBUserReconciler) reconcileGenericUser(ctx context.Context, user i
 	}
 
 	// Fetch referencing secret
-	usr, pw, err := getSecret(ctx, r.Client, user.GetCredentials())
+	usr, pw, addr, err := getSecret(ctx, r.Client, user.GetCredentials())
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.CredentialsNotFoundReason, err.Error())
 		return user, err
 	}
 
-	dbHandler, err := setupMongoDB(ctx, db, rootUsr, rootPw)
+	dbHandler, err := setupMongoDB(ctx, db, rootUsr, rootPw, addr)
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.ConnectionFailedReason, err.Error())
@@ -253,7 +253,7 @@ func (r *MongoDBUserReconciler) reconcileGenericUser(ctx context.Context, user i
 
 func (r *MongoDBUserReconciler) reconcileAtlasUser(ctx context.Context, user infrav1beta1.MongoDBUser, db infrav1beta1.MongoDBDatabase) (infrav1beta1.MongoDBUser, error) {
 	// Fetch referencing root secret
-	pubKey, privKey, err := getSecret(ctx, r.Client, db.GetRootSecret())
+	pubKey, privKey, addr, err := getSecret(ctx, r.Client, db.GetRootSecret())
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.CredentialsNotFoundReason, err.Error())
@@ -261,14 +261,14 @@ func (r *MongoDBUserReconciler) reconcileAtlasUser(ctx context.Context, user inf
 	}
 
 	// Fetch referencing secret
-	usr, pw, err := getSecret(ctx, r.Client, user.GetCredentials())
+	usr, pw, addr, err := getSecret(ctx, r.Client, user.GetCredentials())
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.CredentialsNotFoundReason, err.Error())
 		return user, err
 	}
 
-	dbHandler, err := setupAtlas(ctx, db, pubKey, privKey)
+	dbHandler, err := setupAtlas(ctx, db, pubKey, privKey, addr)
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.ConnectionFailedReason, err.Error())

--- a/internal/controllers/mongodbuser_controller.go
+++ b/internal/controllers/mongodbuser_controller.go
@@ -211,7 +211,7 @@ func (r *MongoDBUserReconciler) reconcile(ctx context.Context, user infrav1beta1
 
 func (r *MongoDBUserReconciler) reconcileGenericUser(ctx context.Context, user infrav1beta1.MongoDBUser, db infrav1beta1.MongoDBDatabase) (infrav1beta1.MongoDBUser, error) {
 	// Fetch referencing root secret
-	rootUsr, rootPw, addr, err := getSecret(ctx, r.Client, db.GetRootSecret())
+	rootUsr, rootPw, _, err := getSecret(ctx, r.Client, db.GetRootSecret())
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.CredentialsNotFoundReason, err.Error())
@@ -253,7 +253,7 @@ func (r *MongoDBUserReconciler) reconcileGenericUser(ctx context.Context, user i
 
 func (r *MongoDBUserReconciler) reconcileAtlasUser(ctx context.Context, user infrav1beta1.MongoDBUser, db infrav1beta1.MongoDBDatabase) (infrav1beta1.MongoDBUser, error) {
 	// Fetch referencing root secret
-	pubKey, privKey, addr, err := getSecret(ctx, r.Client, db.GetRootSecret())
+	pubKey, privKey, _, err := getSecret(ctx, r.Client, db.GetRootSecret())
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.CredentialsNotFoundReason, err.Error())

--- a/internal/controllers/postgresql_test.go
+++ b/internal/controllers/postgresql_test.go
@@ -76,7 +76,7 @@ var _ = Describe("PostgreSQL", func() {
 		interval = time.Second * 1
 	)
 
-	for _, image := range []string{"postgres:12", "postgres:13", "postgres:14", "postgres:15"} {
+	for _, image := range []string{"postgres:15"} {
 		var _ = Describe(image, func() {
 			var (
 				container *postgresqlContainer
@@ -130,7 +130,7 @@ var _ = Describe("PostgreSQL", func() {
 				})
 			})
 
-			Describe("fails if datatabase root secret not found", Ordered, func() {
+			Describe("fails if database root secret not found", Ordered, func() {
 				var (
 					createdDB   *infrav1beta1.PostgreSQLDatabase
 					createdUser *infrav1beta1.PostgreSQLUser
@@ -470,6 +470,7 @@ var _ = Describe("PostgreSQL", func() {
 
 				Describe("creates readWrite user if it does not exists", Ordered, func() {
 					It("adds database", func() {
+						fmt.Println(container.URI)
 						keyDB = types.NamespacedName{
 							Name:      "postgresdatabase-" + randStringRunes(5),
 							Namespace: namespace.Name,

--- a/internal/controllers/postgresql_test.go
+++ b/internal/controllers/postgresql_test.go
@@ -72,11 +72,11 @@ func setupPostgreSQLContainer(ctx context.Context, image string) (*postgresqlCon
 
 var _ = Describe("PostgreSQL", func() {
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 5
 		interval = time.Second * 1
 	)
 
-	for _, image := range []string{"postgres:15"} {
+	for _, image := range []string{"postgres:13", "postgres:14", "postgres:15"} {
 		var _ = Describe(image, func() {
 			var (
 				container *postgresqlContainer
@@ -470,7 +470,6 @@ var _ = Describe("PostgreSQL", func() {
 
 				Describe("creates readWrite user if it does not exists", Ordered, func() {
 					It("adds database", func() {
-						fmt.Println(container.URI)
 						keyDB = types.NamespacedName{
 							Name:      "postgresdatabase-" + randStringRunes(5),
 							Namespace: namespace.Name,

--- a/internal/controllers/postgresqldatabase_controller.go
+++ b/internal/controllers/postgresqldatabase_controller.go
@@ -153,14 +153,14 @@ func (r *PostgreSQLDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 func (r *PostgreSQLDatabaseReconciler) reconcile(ctx context.Context, db infrav1beta1.PostgreSQLDatabase) (infrav1beta1.PostgreSQLDatabase, error) {
-	usr, pw, err := getSecret(ctx, r.Client, db.GetRootSecret())
+	usr, pw, addr, err := getSecret(ctx, r.Client, db.GetRootSecret())
 
 	if err != nil {
 		infrav1beta1.DatabaseNotReadyCondition(&db, infrav1beta1.CredentialsNotFoundReason, err.Error())
 		return db, err
 	}
 
-	rootDBHandler, err := setupPostgreSQL(ctx, db, usr, pw, false)
+	rootDBHandler, err := setupPostgreSQL(ctx, db, usr, pw, addr, false)
 
 	if err != nil {
 		infrav1beta1.DatabaseNotReadyCondition(&db, infrav1beta1.ConnectionFailedReason, err.Error())
@@ -180,7 +180,7 @@ func (r *PostgreSQLDatabaseReconciler) reconcile(ctx context.Context, db infrav1
 		return db, err
 	}
 
-	dbHandler, err := setupPostgreSQL(ctx, db, usr, pw, true)
+	dbHandler, err := setupPostgreSQL(ctx, db, usr, pw, addr, true)
 
 	if err != nil {
 		infrav1beta1.DatabaseNotReadyCondition(&db, infrav1beta1.ConnectionFailedReason, err.Error())

--- a/internal/controllers/postgresqluser_controller.go
+++ b/internal/controllers/postgresqluser_controller.go
@@ -205,7 +205,7 @@ func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, user infrav1be
 	}
 
 	// Fetch referencing secret
-	usr, pw, err := getSecret(ctx, r.Client, user.GetCredentials())
+	usr, pw, _, err := getSecret(ctx, r.Client, user.GetCredentials())
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.CredentialsNotFoundReason, err.Error())
@@ -213,14 +213,14 @@ func (r *PostgreSQLUserReconciler) reconcile(ctx context.Context, user infrav1be
 	}
 
 	// Fetch referencing root secret
-	rootUsr, rootPw, err := getSecret(ctx, r.Client, db.GetRootSecret())
+	rootUsr, rootPw, addr, err := getSecret(ctx, r.Client, db.GetRootSecret())
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.CredentialsNotFoundReason, err.Error())
 		return user, err
 	}
 
-	dbHandler, err := setupPostgreSQL(ctx, db, rootUsr, rootPw, true)
+	dbHandler, err := setupPostgreSQL(ctx, db, rootUsr, rootPw, addr, true)
 
 	if err != nil {
 		infrav1beta1.UserNotReadyCondition(&user, infrav1beta1.ConnectionFailedReason, err.Error())

--- a/internal/database/mongodb.go
+++ b/internal/database/mongodb.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -44,7 +45,13 @@ type MongoDBRepository struct {
 
 func NewMongoDBRepository(ctx context.Context, opts MongoDBOptions) (*MongoDBRepository, error) {
 	o := options.Client()
-	o.ApplyURI(opts.URI)
+
+	uri := opts.URI
+	if !strings.HasPrefix(uri, "mongodb://") {
+		uri = "mongodb://" + uri
+	}
+
+	o.ApplyURI(uri)
 
 	o.SetAuth(options.Credential{
 		Username: opts.Username,

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -28,7 +28,7 @@ const (
 
 func NewPostgreSQLRepository(ctx context.Context, opts PostgreSQLOptions) (*PostgreSQLRepository, error) {
 	uri := opts.URI
-	if !strings.HasPrefix(uri, "postgresql://") {
+	if !strings.HasPrefix(uri, "postgresql://") && !strings.HasPrefix(uri, "postgres://") {
 		uri = "postgresql://" + uri
 	}
 

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -27,13 +27,14 @@ const (
 )
 
 func NewPostgreSQLRepository(ctx context.Context, opts PostgreSQLOptions) (*PostgreSQLRepository, error) {
-	popt, err := url.Parse(opts.URI)
-	if err != nil {
-		return nil, err
+	uri := opts.URI
+	if !strings.HasPrefix(uri, "postgresql://") {
+		uri = "postgresql://" + uri
 	}
 
-	if popt.Scheme == "" {
-		popt.Scheme = "postgres://"
+	popt, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
 	}
 
 	popt.User = url.UserPassword(opts.Username, opts.Password)

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -32,6 +32,10 @@ func NewPostgreSQLRepository(ctx context.Context, opts PostgreSQLOptions) (*Post
 		return nil, err
 	}
 
+	if popt.Scheme == "" {
+		popt.Scheme = "postgres://"
+	}
+
 	popt.User = url.UserPassword(opts.Username, opts.Password)
 
 	if opts.DatabaseName != "" {


### PR DESCRIPTION
## Current situation
<!--- Shortly describe the current situation -->

## Proposal
This pr adds support for reading the database uri/host from the rootSecret (addressField) instead spec.address. 
If both are set spec.address is preferred.

This is useful for fully autonomous systems where the db instance might also be provisioned via k8s and the endpoint is written to a secret since the postgres deployer has no information about the db-controller.
For example this makes it possible to reference a connection secret created by crossplane aws provider.